### PR TITLE
Fix GPIO Setup for Pins >= 32

### DIFF
--- a/main/app_main.c
+++ b/main/app_main.c
@@ -174,7 +174,7 @@ static uint8_t at_exeCmdGpioInit(uint8_t para_num)
 		return ESP_AT_RESULT_CODE_ERROR;
 	}
 	
-	gpio_pad_select_gpio(pin);
+	gpio_reset_pin(pin);
 	
 	/* if set to output OD the register value to be programmed is 4 */
 	if (dir == 3) dir = GPIO_MODE_OUTPUT_OD;


### PR DESCRIPTION
The `gpio_pad_select_gpio` fails for pins >= 32. The function isn't documented in the ESP IDF and there's a forum mention about it at https://www.esp32.com/viewtopic.php?t=25505 which indicates gpio_reset_pin works better.